### PR TITLE
Double display for image linked to midi

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -403,7 +403,7 @@ class syntax_plugin_abc extends DokuWiki_Syntax_Plugin {
                 if($midFile) {
                     $display = '<a href="'.ml($mediaNS.$this->_getFileID($midFile)).'">'.$display.'</a>';
                 }
-                $display .= '<p>'.$display.'</p>'.NL;
+                $display = '<p>'.$display.'</p>'.NL;
                 break;
 
             // image with list of abc, midi, ps/pdf


### PR DESCRIPTION
We are getting the link (plus the image) included twice in the content, this seems to be due to the string concatenation instead of attribution in the "image linked to midi" case in the "_showFiles". This change fixed the issue.